### PR TITLE
Fix module URL

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
   "title": "Small Visual Tweaks",
   "description": "Formerly known as ‘Playlist Down’, this module adds some small visual tweaks to Foundry's UI. It currently highlights the ‘Currently Playing’ tracks, truncates long names in chat, and adds badges to more easily identify Private/Blind Rolls and Whispers.",
   "author": "Rafael “Miriadis” Masoni (Miriadis#9152)",
-  "url": "https://gitlab.com/the-stash/svt",
+  "url": "https://github.com/miriadis/svt",
   "version": "1.1.4",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "11",

--- a/module.json
+++ b/module.json
@@ -1,12 +1,14 @@
 {
-  "name": "svt",
+  "id": "svt",
   "title": "Small Visual Tweaks",
   "description": "Formerly known as ‘Playlist Down’, this module adds some small visual tweaks to Foundry's UI. It currently highlights the ‘Currently Playing’ tracks, truncates long names in chat, and adds badges to more easily identify Private/Blind Rolls and Whispers.",
-  "author": "Rafael “Miriadis” Masoni (Miriadis#9152)",
+  "authors": [
+    {
+      "name": "Rafael “Miriadis” Masoni (Miriadis#9152)"
+    }
+  ],
   "url": "https://github.com/miriadis/svt",
   "version": "1.1.4",
-  "minimumCoreVersion": "9",
-  "compatibleCoreVersion": "11",
   "compatibility": {
     "minimum": "9",
     "verified": "11"

--- a/module.json
+++ b/module.json
@@ -9,16 +9,16 @@
     }
   ],
   "url": "https://github.com/miriadis/svt",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "compatibility": {
-    "minimum": "9",
+    "minimum": "10",
     "verified": "11"
   },
   "styles": [
     "./styles/svt.css"
   ],
   "socket": false,
-  "manifest": "https://raw.githubusercontent.com/miriadis/svt/1.1.4/module.json",
-  "download": "https://github.com/miriadis/svt/archive/refs/tags/1.1.4.zip",
+  "manifest": "https://raw.githubusercontent.com/miriadis/svt/1.1.5/module.json",
+  "download": "https://github.com/miriadis/svt/archive/refs/tags/1.1.5.zip",
   "protected": false
 }

--- a/module.json
+++ b/module.json
@@ -4,7 +4,8 @@
   "description": "Formerly known as ‘Playlist Down’, this module adds some small visual tweaks to Foundry's UI. It currently highlights the ‘Currently Playing’ tracks, truncates long names in chat, and adds badges to more easily identify Private/Blind Rolls and Whispers.",
   "authors": [
     {
-      "name": "Rafael “Miriadis” Masoni (Miriadis#9152)"
+      "name": "Rafael “Miriadis” Masoni",
+      "discord": "Miriadis#9152"
     }
   ],
   "url": "https://github.com/miriadis/svt",


### PR DESCRIPTION
Just a small thing that tripped me up for a moment, plus clearing up some console warnings 😉

Technically speaking, this manifest is probably unreadable by v9 now, so you might want to also bump the minimum version? You could reinstate the deleted properties, but that would likely still cause warnings on v10/11; I leave it up to you to decide!